### PR TITLE
fixes #6 - missing user mention

### DIFF
--- a/src/app/api/link/authenticate/route.js
+++ b/src/app/api/link/authenticate/route.js
@@ -166,6 +166,7 @@ export async function GET(request) {
     });
   } catch (error) {
     await sendErrorLogsToDiscord({
+      content: `<@${discordUser.id}>`,
       embed: {
         title: "Unknown Error in Authentication",
         color: 0xff0000,

--- a/src/app/api/link/authenticate/route.js
+++ b/src/app/api/link/authenticate/route.js
@@ -60,6 +60,7 @@ export async function GET(request) {
 
     if (response.status !== 200 || !response.data?.status) {
       await sendErrorLogsToDiscord({
+        content: `<@${discordUser.id}>`,
         embed: {
           title: "PESU Auth Error",
           color: 0xff0000,


### PR DESCRIPTION
This PR fixes the issue #6 

tags the Discord user in the message -

```js
 await sendErrorLogsToDiscord({
      content: `<@${discordUser.id}>`,
      embed: {
        title: "Unknown Error in Authentication",
        color: 0xff0000,
        timestamp: new Date(),
        footer: {
          text: "PESU Bot",
        },
        fields: [
```

updated this section of the code (as above)